### PR TITLE
Save apikey to Keychain Access.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Download and double-click.
 
 Register Mackcerel API Key.
 
-- save to `apikey` file in workflow's data folder
+- `apikey` saved in your `Keychain Access.app`
 
 ```
 mackerel api <XXXX>


### PR DESCRIPTION
<img width="762" alt="keychain-access" src="https://user-images.githubusercontent.com/1402528/33303626-95013e08-d447-11e7-9a82-8a8b82365dcc.png">

More secure compared to the file :)

- Thanks for the URL.
  - [Go で Datadog の Alfred Workflow を作った](https://blog.tsub.me/post/create-alfred-workflow/)